### PR TITLE
Added target tractability and safety testing scenarios

### DIFF
--- a/platform-api-qc.yml
+++ b/platform-api-qc.yml
@@ -114,6 +114,16 @@ checkomatic:
         - len(o.tractability.smallmolecule.buckets) == 0
         - len(o.tractability.antibody.buckets) == 0
         - len(o.tractability.other_modalities.buckets) == 0
+      ENSG00000118777:
+        - o.approved_symbol == 'ABCG2'
+        # test that response includes experimental toxicity data from Tox21 and eTOX
+        - len(o.safety.experimental_toxicity) > 0
+        - |-
+          parser = jp.parse('safety.experimental_toxicity[*].data_source')
+          output = 'Tox21' in to_vlist(parser.find(d))
+        - |-
+          parser = jp.parse('safety.experimental_toxicity[*].data_source')
+          output = 'eTOX' in to_vlist(parser.find(d))
     diseases:
       Orphanet_262:
         - o.label == 'Duchenne and Becker muscular dystrophy'

--- a/platform-api-qc.yml
+++ b/platform-api-qc.yml
@@ -93,6 +93,27 @@ checkomatic:
         - |-
           parser = jp.parse('reactome[*].value."pathway name"')
           output = 'Negative regulation of MAPK pathway' in to_vlist(parser.find(d))
+      ENSG00000171560:
+        - o.approved_symbol == 'FGA'
+        # test that other modality bucket 1 tractability data is available
+        - (1 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000227507:
+        - o.approved_symbol == 'LTB'
+        # test that other modality bucket 2 tractability data is available
+        - (2 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000151892:
+        - o.approved_symbol == 'GFRA1'
+        # test that other modality bucket 3 tractability data is available
+        - (3 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000184900:
+        - o.approved_symbol == 'SUMO3'
+        # test that all bucket arrays are empty as no tractability data is available
+        - len(o.tractability.smallmolecule.buckets) == 0
+        - len(o.tractability.antibody.buckets) == 0
+        - len(o.tractability.other_modalities.buckets) == 0
     diseases:
       Orphanet_262:
         - o.label == 'Duchenne and Becker muscular dystrophy'

--- a/platform-api.yml
+++ b/platform-api.yml
@@ -114,6 +114,16 @@ checkomatic:
         - len(o.tractability.smallmolecule.buckets) == 0
         - len(o.tractability.antibody.buckets) == 0
         - len(o.tractability.other_modalities.buckets) == 0
+      ENSG00000118777:
+        - o.approved_symbol == 'ABCG2'
+        # test that response includes experimental toxicity data from Tox21 and eTOX
+        - len(o.safety.experimental_toxicity) > 0
+        - |-
+          parser = jp.parse('safety.experimental_toxicity[*].data_source')
+          output = 'Tox21' in to_vlist(parser.find(d))
+        - |-
+          parser = jp.parse('safety.experimental_toxicity[*].data_source')
+          output = 'eTOX' in to_vlist(parser.find(d))
     diseases:
       Orphanet_262:
         - o.label == 'Duchenne and Becker muscular dystrophy'

--- a/platform-api.yml
+++ b/platform-api.yml
@@ -93,6 +93,27 @@ checkomatic:
         - |-
           parser = jp.parse('reactome[*].value."pathway name"')
           output = 'Negative regulation of MAPK pathway' in to_vlist(parser.find(d))
+      ENSG00000171560:
+        - o.approved_symbol == 'FGA'
+        # test that other modality bucket 1 tractability data is available
+        - (1 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000227507:
+        - o.approved_symbol == 'LTB'
+        # test that other modality bucket 2 tractability data is available
+        - (2 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000151892:
+        - o.approved_symbol == 'GFRA1'
+        # test that other modality bucket 3 tractability data is available
+        - (3 in o.tractability.other_modalities.buckets)
+        - len(o.tractability.other_modalities.buckets) > 0
+      ENSG00000184900:
+        - o.approved_symbol == 'SUMO3'
+        # test that all bucket arrays are empty as no tractability data is available
+        - len(o.tractability.smallmolecule.buckets) == 0
+        - len(o.tractability.antibody.buckets) == 0
+        - len(o.tractability.other_modalities.buckets) == 0
     diseases:
       Orphanet_262:
         - o.label == 'Duchenne and Becker muscular dystrophy'


### PR DESCRIPTION
In this PR, I have added testing scenarios to both the QC and production API rules files to test for:

- Targets with experimental toxicity data from both eTOX and Tox21
- Targets with other clinical modality tractability data (buckets 1, 2, and 3)
- Targets with no tractability data

This PR resolves the following tickets:

- opentargets/platform#962
- opentargets/platform#932
- opentargets/platform#784